### PR TITLE
[NEW] Add controller context to ChatSection

### DIFF
--- a/Example/RocketChatViewController Example/Controller/ChatViewController.swift
+++ b/Example/RocketChatViewController Example/Controller/ChatViewController.swift
@@ -60,7 +60,7 @@ final class ChatViewController: RocketChatViewController {
             if var messageSectionModel = first.base.object.base as? MessageSectionModel {
                 messageSectionModel.message.text = "TEST TEST TEST"
                 data.remove(at: 0)
-                let chatSection = MessageChatSection(object: AnyDifferentiable(messageSectionModel))
+                let chatSection = MessageChatSection(object: AnyDifferentiable(messageSectionModel), controllerContext: nil)
                 data.insert(AnyChatSection(chatSection), at: 0)
                 updateData()
             }

--- a/Example/RocketChatViewController Example/Controller/MessageChatSection.swift
+++ b/Example/RocketChatViewController Example/Controller/MessageChatSection.swift
@@ -12,6 +12,7 @@ import RocketChatViewController
 
 struct MessageChatSection: ChatSection {
     var object: AnyDifferentiable
+    weak var controllerContext: UIViewController?
 
     // MARK: Section Controller
 

--- a/Example/RocketChatViewController Example/DataControllerPlaceholder.swift
+++ b/Example/RocketChatViewController Example/DataControllerPlaceholder.swift
@@ -61,7 +61,8 @@ struct DataControllerPlaceholder {
                 MessageChatSection(
                     object: AnyDifferentiable(
                         object
-                    )
+                    ),
+                    controllerContext: nil
                 )
             )
 

--- a/RocketChatViewController/Classes/RocketChatViewController.swift
+++ b/RocketChatViewController/Classes/RocketChatViewController.swift
@@ -64,11 +64,21 @@ public struct AnyChatItem: ChatItem, Differentiable {
  */
 
 public struct AnyChatSection: ChatSection {
+    public weak var controllerContext: UIViewController? {
+        get {
+            return base.controllerContext
+        }
+
+        set(newControllerContext) {
+            base.controllerContext = newControllerContext
+        }
+    }
+
     public var object: AnyDifferentiable {
         return base.object
     }
 
-    public let base: ChatSection
+    public var base: ChatSection
 
     public init<D: ChatSection>(_ base: D) {
         self.base = base
@@ -113,6 +123,7 @@ fileprivate extension AnyChatSection {
 
 public protocol ChatSection {
     var object: AnyDifferentiable { get }
+    var controllerContext: UIViewController? { get set }
     func viewModels() -> [AnyChatItem]
     func cell(for viewModel: AnyChatItem, on collectionView: UICollectionView, at indexPath: IndexPath) -> ChatCell
 }


### PR DESCRIPTION
This PR enables a `ChatSection` to do any operation that requires it to know the current controller context, such as pushing a new controller. 

It's useful when handling cell-triggered actions on the `ChatSection`, we have the object context and now the controller context so we can basically perform any operation we want to. 

I could've created a new protocol such as `ChatSectionControllerContext` or something, but since not all `ChatSection`s will use it I found it more practical to add an optional property. What do you guys think about it?