### PR TITLE
[CHORE] Stop using updateRows in favor of reloadItems

### DIFF
--- a/RocketChatViewController/Classes/RocketChatViewController.swift
+++ b/RocketChatViewController/Classes/RocketChatViewController.swift
@@ -306,16 +306,7 @@ open class RocketChatViewController: UICollectionViewController {
 
             DispatchQueue.main.async {
                 let changeset = StagedChangeset(source: strongSelf.internalData, target: strongSelf.data.map({ $0.toArraySection }))
-                collectionView.reload(using: changeset, updateRows: { indexPaths in
-                    for indexPath in indexPaths {
-                        if collectionView.indexPathsForVisibleItems.contains(indexPath),
-                            var cell = collectionView.cellForItem(at: indexPath) as? ChatCell {
-                            let viewModel = strongSelf.internalData[indexPath.section].elements[indexPath.item]
-                            cell.viewModel = viewModel
-                            cell.configure()
-                        }
-                    }
-                }, interrupt: { $0.changeCount > 100 }) { newData in
+                collectionView.reload(using: changeset, interrupt: { $0.changeCount > 100 }) { newData in
                     strongSelf.internalData = newData
 
                     let newSections = newData.map { $0.model }

--- a/RocketChatViewController/Classes/UIKitExtension.swift
+++ b/RocketChatViewController/Classes/UIKitExtension.swift
@@ -25,7 +25,6 @@ public extension UICollectionView {
     ///              The collection should be set to dataSource of UICollectionView.
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
-        updateRows: ([IndexPath]) -> Void,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
         ) {
@@ -68,7 +67,7 @@ public extension UICollectionView {
                 }
 
                 if !changeset.elementUpdated.isEmpty {
-                    updateRows(changeset.elementUpdated.map { IndexPath(item: $0.element, section: $0.section) })
+                    reloadItems(at: changeset.elementUpdated.map { IndexPath(item: $0.element, section: $0.section) })
                 }
 
                 for (source, target) in changeset.elementMoved {


### PR DESCRIPTION
Update rows doesn't recalculates the row's size. It was causing the new TextAttachment component to behave wrong.